### PR TITLE
Use platform-specific read_at to read the files.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ license = "MPL2"
 name = "frfs"
 repository = "https://github.com/Tim-Paik/FRFS"
 version = "0.2.0"
+rust-version = "1.66"
 
 [dependencies]
 argh = { version = "0.1", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -191,8 +191,8 @@ impl Seek for File {
                 self.offset = if offset >= 0 {
                     self.header.file_size
                 } else {
-                    self.header.file_size - offset.unsigned_abs()
-                };
+                    self.header.file_size.wrapping_add_signed(offset)
+                }
             }
         }
         Ok(self.offset)

--- a/src/read_at.rs
+++ b/src/read_at.rs
@@ -1,0 +1,19 @@
+use std::{fs::File, io::Result};
+
+#[cfg(windows)]
+pub fn read_at(f: &File, buf: &mut [u8], offset: u64) -> Result<usize> {
+    use std::os::windows::fs::FileExt;
+    f.seek_read(buf, offset)
+}
+
+#[cfg(unix)]
+pub fn read_at(f: &File, buf: &mut [u8], offset: u64) -> Result<usize> {
+    use std::os::unix::fs::FileExt;
+    f.read_at(buf, offset)
+}
+
+#[cfg(target_os = "wasi")]
+pub fn read_at(f: &File, buf: &mut [u8], offset: u64) -> Result<usize> {
+    use std::os::wasi::fs::FileExt;
+    f.read_at(buf, offset)
+}

--- a/src/read_at.rs
+++ b/src/read_at.rs
@@ -3,6 +3,14 @@ use std::{fs::File, io::Result};
 #[cfg(windows)]
 pub fn read_at(f: &File, buf: &mut [u8], offset: u64) -> Result<usize> {
     use std::os::windows::fs::FileExt;
+    // Note we use `seek_read` here to imitate `read_at`.
+    //
+    // `read_at` is `pread`/`pread64` on Unix, which will not update file
+    // cursor after reading. However on Windows, all reading operations
+    // is finally `NtReadFile`, which will certainly update the file cursor.
+    //
+    // We use `seek_read` here because we don't care about the file cursor
+    // at all. We just need an atomic operation to seek and read.
     f.seek_read(buf, offset)
 }
 


### PR DESCRIPTION
* 写了个单独的 mod 处理 read_at。如果有一天这个方法进入 std，可以直接删掉这个文件。
* 加入了自己处理 offset 的逻辑。
* 删掉了 `frfs::File::try_clone`。这是因为 `try_clone` 要求两个 `File` 的操作互相影响，我们反正也不需要这个功能，就删了。